### PR TITLE
change keyserver accoding to installation guide

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,7 @@
 ---
 # defaults file for ros
 
-ros_keyserver: hkp://keyserver.ubuntu.com:80              # Retrieved from ROS Installation instructions
-ros_key_id: C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654      # Retrieved from ROS Installation instructions
+ros_keyserver: https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc         # Updated from ROS Installation instructions
 ros_repository_url: http://packages.ros.org/ros/ubuntu    # Retrieved from ROS Installation instructions
 
 ros_distribution: noetic     # noetic OR melodic OR kinetic (automatically discoverable according to Ubuntu version)

--- a/tasks/ros-install.yml
+++ b/tasks/ros-install.yml
@@ -6,8 +6,8 @@
 
 - name: Setup ROS keys
   apt_key:
-    keyserver: "{{ ros_keyserver }}"
-    id: "{{ ros_key_id }}"
+    state: present
+    url: "{{ ros_keyserver }}"
 
 - name: Setup sources.list
   apt_repository:


### PR DESCRIPTION
it seems that the installation guide has changed to retrieve the key directly from github.
http://wiki.ros.org/noetic/Installation/Ubuntu#Installation.2FUbuntu.2FSources.Set_up_your_keys